### PR TITLE
Fix fetch clause paths and support return value

### DIFF
--- a/packages/lezer-surrealql/src/surrealql.grammar
+++ b/packages/lezer-surrealql/src/surrealql.grammar
@@ -332,10 +332,8 @@ CreateStatement {
 
 SelectStatement {
 	(select)
-	(
-		valueKeyword Predicate |
-		commaSep<inclusivePredicate> OmitClause?
-	)
+	(Fields)
+	(OmitClause?)
 	(from)
 	(only)?
 	(
@@ -665,6 +663,13 @@ RecurseRange {
 	number rangeOp number
 }
 
+// Fields
+
+Fields {
+	valueKeyword Predicate |
+	commaSep<inclusivePredicate>
+}
+
 // Objects
 
 ObjectKey {
@@ -968,7 +973,7 @@ OverwriteClause[since=2_0_0] {
 
 ReturnClause {
 	return
-	( before | after | diff | commaSep<inclusivePredicate> )
+	( before | after | diff | Fields )
 }
 
 TimeoutClause {

--- a/packages/lezer-surrealql/src/surrealql.grammar
+++ b/packages/lezer-surrealql/src/surrealql.grammar
@@ -986,7 +986,7 @@ TempfilesClause[since=2_0_0] {
 
 FetchClause {
 	fetch
-	commaSep<Ident>
+	commaSep<Path>
 }
 
 StartClause {


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

- Specifying dot separated paths in FETCH clauses breaks highlighting
- RETURN VALUE does not highlight

## What does this change do?

Use Path instead of Ident, and extract field selection to reusable Fields type

## What is your testing strategy?

CI

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealql-codemirror/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealql-codemirror/blob/main/CONTRIBUTING.md)
