### PR TITLE
Allow back pointing arrows in RELATE

### DIFF
--- a/packages/lezer-surrealql/src/surrealql.grammar
+++ b/packages/lezer-surrealql/src/surrealql.grammar
@@ -432,7 +432,7 @@ IfElseStatement {
 relateSubject { Array | Ident | FunctionCall | VariableName | RecordId }
 RelateStatement {
 	relate only?
-	relateSubject "->" relateSubject "->" relateSubject
+	relateSubject ("->" | "<-") relateSubject ("->" | "<-") relateSubject
 	( ContentClause | SetClause )?
 	ReturnClause?
 	TimeoutClause?


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## What is the motivation?

The following statement does not parse
```
RELATE test:foo<-edge<-test:bar
```

## What does this change do?

Adds support

## What is your testing strategy?

CI

## Is this related to any issues?

If this pull request is related to any other pull request or issue, or resolves any issues - then link all related pull requests and issues here.

## Have you read the [Contributing Guidelines](https://github.com/surrealdb/surrealql-codemirror/blob/main/CONTRIBUTING.md)?

- [x] I have read the [Contributing Guidelines](https://github.com/surrealdb/surrealql-codemirror/blob/main/CONTRIBUTING.md)
