### PR TITLE
Add bunfig with minimumReleaseAge for supply-chain safety

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
 		},
 		"packages/codemirror-surrealql": {
 			"name": "@surrealdb/codemirror",
-			"version": "1.0.3",
+			"version": "1.0.5",
 			"dependencies": {
 				"@codemirror/language": "^6.10.3",
 				"@codemirror/lint": "^6.8.2",
@@ -33,7 +33,7 @@
 		},
 		"packages/lezer-surrealql": {
 			"name": "@surrealdb/lezer",
-			"version": "1.0.3",
+			"version": "1.0.5",
 			"dependencies": {
 				"@lezer/common": "^1.2.3",
 				"@lezer/highlight": "^1.2.1",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,17 @@
+[install]
+# Only install package versions published at least 7 days ago
+minimumReleaseAge = 604800
+
+# These packages will bypass the 7-day minimum age requirement
+minimumReleaseAgeExcludes = [
+	"@types/bun",
+	"typescript",
+	"surrealdb",
+	"@surrealdb/wasm",
+	"@surrealdb/lezer",
+	"@surrealdb/codemirror",
+	"@surrealdb/surql-fmt",
+	"@surrealdb/ql-wasm",
+	"@surrealdb/cbor",
+	"@surrealdb/ui",
+]


### PR DESCRIPTION
Adds root bunfig.toml: minimumReleaseAge (7 days) and minimumReleaseAgeExcludes. Improves supply-chain safety for CI and contributors.

Made with [Cursor](https://cursor.com)